### PR TITLE
fix: Max HP formula

### DIFF
--- a/src/lib/trainers/pokemon-details/Editor.svelte
+++ b/src/lib/trainers/pokemon-details/Editor.svelte
@@ -78,7 +78,7 @@
 				level: new Level(level),
 				ac,
 				hp: {
-					current: pokemon.hp.current + (maxHp - pokemon.hp.max),
+					current: Math.min(pokemon.hp.current + Math.max(0, maxHp - pokemon.hp.max), maxHp),
 					max: maxHp,
 				},
 				hitDice: {


### PR DESCRIPTION
Fixes #56

Decreasing Max HP was always decreasing Current HP regardless of Current HP value, which led to negative values and undesired results.

### This is how it works now

Current HP: 10
Max HP: 40

**Scenario 1**
Max HP increases to 60.
Result: Current HP increases to 30.

**Scenario 2**
Max HP decreases to 20.
Result: Current HP remains at 10.

**Scenario 3**
Max HP decreases to 5.
Result: Current HP decreases to 5 to match Max HP.