### PR TITLE
fix: dialog menu - title with multiple lines

### DIFF
--- a/src/lib/ui/layout/MainNavigation.svelte
+++ b/src/lib/ui/layout/MainNavigation.svelte
@@ -68,7 +68,7 @@
 							<div class="bubble" aria-hidden="true">
 								<svelte:component this={item.icon} />
 							</div>
-							<span>{item.name}</span>
+							<span class="bubble-title">{item.name}</span>
 						</a>
 					</li>
 				{/each}
@@ -203,6 +203,10 @@
 	} .bubble :global(svg) {
 		inline-size: 100%;
 		block-size: 100%;
+	}
+
+	.bubble-title {
+		text-align: center;
 	}
 
 	.center-column {


### PR DESCRIPTION
Before: 
<img width="668" height="430" alt="before" src="https://github.com/user-attachments/assets/727d1b13-b4c2-4767-b38c-34181f6ab032" />

After: 
<img width="663" height="426" alt="after" src="https://github.com/user-attachments/assets/850a664e-3220-44da-b84f-af9f27f1a537" />


Small fix but concerns me when translating titles from the dialog that become larger than a single line.