### PR TITLE
fix: correct creature -> creatures plural typos in move descriptions

### DIFF
--- a/static/data/moves.json
+++ b/static/data/moves.json
@@ -6868,7 +6868,7 @@
 			"duration": "instantaneous",
 			"range": "40ft",
 			"description": [
-				"Two pillars of raging hot flames explode out from you and leap towards up to two creature in range. The creature(s) targeted must succeed on a DEX save against your Move DC for each pillar, taking 1d8 + MOVE fire damage on a failure, or half as much on a success. Creatures that fail the save by 5 or more become burned."
+				"Two pillars of raging hot flames explode out from you and leap towards up to two creatures in range. The creature(s) targeted must succeed on a DEX save against your Move DC for each pillar, taking 1d8 + MOVE fire damage on a failure, or half as much on a success. Creatures that fail the save by 5 or more become burned."
 			],
 			"higherLevels": "The damage dice roll for this move changes to 2d6 at level 5, 4d4 at level 10, and 3d10 at level 17.",
 			"tm": {
@@ -7266,7 +7266,7 @@
 			"duration": "instantaneous",
 			"range": "self (10ft radius)",
 			"description": [
-				"A wheel of flame explodes out from you in a 10 foot radius. All creature in the area must succeed on a DEX save against your Move DC, taking 1d10 + MOVE fire damage on a fail and half as much on a save. If the user is frozen, this move can still be used, thawing out the creature during the attack"
+				"A wheel of flame explodes out from you in a 10 foot radius. All creatures in the area must succeed on a DEX save against your Move DC, taking 1d10 + MOVE fire damage on a fail and half as much on a save. If the user is frozen, this move can still be used, thawing out the creature during the attack"
 			],
 			"higherLevels": "The damage dice roll for this move changes to 2d8 at level 5, 5d4 at level 10, and 4d8 at level 17.",
 			"damage": {
@@ -8004,7 +8004,7 @@
 			"duration": "instantaneous",
 			"range": "self (15ft radius)",
 			"description": [
-				"You summon a whirlwind of jagged branches and razor sharp leaves that batter all creatures in a 15-foot-radius circle, centered on you. All creature caught in the flurry must make a DEX saving throw against your Move DC, taking 3d8 + MOVE grass damage on a failure, and half as much on a success. This move saps you of energy, and may not activate it again until after the end of your next turn."
+				"You summon a whirlwind of jagged branches and razor sharp leaves that batter all creatures in a 15-foot-radius circle, centered on you. All creatures caught in the flurry must make a DEX saving throw against your Move DC, taking 3d8 + MOVE grass damage on a failure, and half as much on a success. This move saps you of energy, and may not activate it again until after the end of your next turn."
 			],
 			"higherLevels": "The damage dice roll for this move changes to 5d6 at level 5, 4d12 at level 10, and 8d8 at level 17.",
 			"damage": {
@@ -12384,7 +12384,7 @@
 			"duration": "instantaneous",
 			"range": "self (30ft radius)",
 			"description": [
-				"You shake the ground with an earth-shattering quake. All creature in range must make a DEX save against your Move DC, taking half damage on a success and full damage on a fail. Creatures in range that are burrowed or in the invulnerable stage of Dig take double damage from this move. Roll a d100 on the table below to determine damage. Raised creatures are immune to the effects and damage of this move.",
+				"You shake the ground with an earth-shattering quake. All creatures in range must make a DEX save against your Move DC, taking half damage on a success and full damage on a fail. Creatures in range that are burrowed or in the invulnerable stage of Dig take double damage from this move. Roll a d100 on the table below to determine damage. Raised creatures are immune to the effects and damage of this move.",
 				{
 					"type": "table",
 					"headers": [
@@ -19544,7 +19544,7 @@
 			"duration": "instantaneous",
 			"range": "50ft",
 			"description": [
-				"While you are asleep, you may activate this move to create a harsh noise that damages all creature within range for 1d8 + MOVE normal damage."
+				"While you are asleep, you may activate this move to create a harsh noise that damages all creatures within range for 1d8 + MOVE normal damage."
 			],
 			"higherLevels": "The damage dice roll for this move changes to 2d6 at level 5, 4d4 at level 10, and 3d10 at level 17.",
 			"damage": {
@@ -19707,7 +19707,7 @@
 			"duration": "instantaneous",
 			"range": "self (20ft radius)",
 			"description": [
-				"You unleash a deafening sound that harms creature in a 20-foot-radius circle, centered on you. Creatures in range must make a CON save against your Move DC, taking 16 flat normal damage on a fail, or half as much on a success."
+				"You unleash a deafening sound that harms creatures in a 20-foot-radius circle, centered on you. Creatures in range must make a CON save against your Move DC, taking 16 flat normal damage on a fail, or half as much on a success."
 			],
 			"save": {
 				"attribute": [


### PR DESCRIPTION
Fixes #491

## Changes

Corrects 6 instances where `creature` should be `creatures` (plural) in move descriptions:

| Move | Before | After |
|------|--------|-------|
| Fire Blast | "up to two **creature** in range" | "up to two **creatures** in range" |
| Flame Wheel | "All **creature** in the area" | "All **creatures** in the area" |
| Frenzy Plant | "All **creature** caught in the flurry" | "All **creatures** caught in the flurry" |
| Magnitude | "All **creature** in range" | "All **creatures** in range" |
| Snore | "damages all **creature** within range" | "damages all **creatures** within range" |
| Sonic Boom | "harms **creature** in a 20-foot-radius" | "harms **creatures** in a 20-foot-radius" |

Single file changed: `static/data/moves.json` (6 lines)