### PR TITLE
Feature - Poke Box DB migrations and tests

### DIFF
--- a/supabase/migrations/20260821162558_pokemon_box.sql
+++ b/supabase/migrations/20260821162558_pokemon_box.sql
@@ -1,0 +1,167 @@
+-- The Box is a trainer's PC storage: one flat, unlimited list per trainer. A
+-- pokemon is either in the party or in the box, so the whole feature is a
+-- single piece of state on the pokemon row.
+--
+-- It lives on private.pokemon rather than in a table of its own because a
+-- pokemon's identity has to survive a deposit: transfer codes, moves, held
+-- items, feats, abilities and the avatar filename all key off pokemon.id, and
+-- moving the row would mean moving all of them with it.
+--
+-- It is a location rather than a boolean so that a future place to keep a
+-- pokemon -- a daycare, a second box -- is a new value instead of a reshaped
+-- schema. Adding one means extending the constraint below.
+--
+-- get_pokemon RETURNS SETOF private.pokemon and SELECTs *, so the new column
+-- reaches the API with no signature change and no DROP FUNCTION -- the same
+-- free ride the tags column got.
+
+-- Both clauses in one ALTER TABLE so the table is scanned once. On PG11+ a
+-- constant default is a catalog-only change, so no existing row is rewritten
+-- and every pokemon that already exists starts out in the party.
+--
+-- Unlike status or gender, which are only ever displayed, the app *branches* on
+-- this value to decide which list a pokemon appears in. An unrecognised value
+-- would put a pokemon in neither list and hide it from its own trainer, so the
+-- set of valid locations is enforced here rather than by client convention.
+ALTER TABLE private.pokemon
+	ADD COLUMN storage VARCHAR(255) NOT NULL DEFAULT 'party', -- 'party' or 'box'
+	ADD CONSTRAINT must_be_a_known_storage_location CHECK (storage IN ('party', 'box'));
+
+-- Moving a pokemon is its own function rather than another parameter on
+-- update_pokemon. update_pokemon is handed a whole pokemon by the editor and by
+-- the tag updater, so threading the location through it would let any stale
+-- copy of a pokemon silently relocate it. It also has to hand out a party rank
+-- on the way in, and rank is deliberately something update_pokemon never
+-- touches -- only add_pokemon, reorder_pokemon and accept_pokemon_transfer do.
+--
+-- add_pokemon needs nothing: a caught pokemon always joins the party, which the
+-- column default already gives us, and adding a parameter there would mint yet
+-- another overload of an already heavily overloaded function.
+--
+-- _storage is not defaulted, so a caller that omits it errors instead of
+-- silently relocating the pokemon. Validation is left entirely to the check
+-- constraint, so there is only one place to edit when a location is added.
+CREATE OR REPLACE FUNCTION set_pokemon_storage(
+	_write_key VARCHAR(32),
+	_id INT,
+	_storage VARCHAR(255)
+) RETURNS INT AS $$
+DECLARE affected_rows INT;
+BEGIN
+	UPDATE private.pokemon p SET
+		storage = _storage,
+		-- A pokemon rejoining the party goes to the end of it, the same rule
+		-- accept_pokemon_transfer uses. MAX, not COUNT, because gaps in the rank
+		-- sequence are allowed -- every deposit leaves one behind. The subquery
+		-- still sees this row's old rank, so the result is always greater than
+		-- every rank the trainer currently has.
+		--
+		-- The p.storage guard makes the call idempotent. Without it, moving a
+		-- pokemon that is already in the party (a double click, a stale tab)
+		-- would shunt it to the back again. Leaving the party never renumbers, so
+		-- the rest of the party keeps its order.
+		rank = CASE WHEN p.storage <> 'party' AND _storage = 'party' THEN (
+			SELECT COALESCE(MAX(sibling.rank), 0) + 1
+			FROM private.pokemon sibling
+			WHERE sibling.trainer_id = p.trainer_id
+		) ELSE p.rank END
+	FROM private.trainers t
+	WHERE
+		p.id = _id
+		AND p.trainer_id = t.id
+		AND t.write_key = _write_key;
+
+	-- The write-access gate is the UPDATE's own WHERE clause, so ROW_COUNT is
+	-- already the permission answer: 0 means the pokemon does not exist or the
+	-- key does not own it.
+	GET DIAGNOSTICS affected_rows := ROW_COUNT;
+
+	RETURN affected_rows;
+END $$ LANGUAGE PLPGSQL VOLATILE SECURITY DEFINER;
+
+-- Unchanged from 20260609141522_transfer_codes.sql except for the storage
+-- column. This function builds its column list from information_schema, so
+-- every new column on private.pokemon is copied automatically -- which for
+-- storage is the wrong behaviour: a pokemon transferred out of a box would
+-- arrive invisible in the recipient's box, contradicting the _new_rank below,
+-- which already assumes a party slot. It is overridden rather than merely
+-- excluded so it stays correct if more locations are added later.
+CREATE OR REPLACE FUNCTION accept_pokemon_transfer(
+	_write_key VARCHAR(32),
+	_transfer_code VARCHAR(32)
+) RETURNS INT AS $$
+DECLARE
+	_new_trainer_id UUID;
+	_src_pokemon_id INT;
+	_new_pokemon_id INT;
+	_new_rank       INT;
+	_cols           TEXT;
+BEGIN
+	-- Resolve the destination trainer from the write key.
+	SELECT id INTO _new_trainer_id
+	FROM private.trainers
+	WHERE write_key = _write_key;
+
+	IF _new_trainer_id IS NULL THEN
+		RAISE EXCEPTION 'Invalid write key';
+	END IF;
+
+	-- Resolve the source pokemon from the transfer code.
+	SELECT pokemon_id INTO _src_pokemon_id
+	FROM private.transfer_codes
+	WHERE transfer_code = _transfer_code;
+
+	IF _src_pokemon_id IS NULL THEN
+		RAISE EXCEPTION 'Invalid or expired transfer code';
+	END IF;
+
+	-- Next rank = highest existing rank for the destination trainer + 1.
+	-- COALESCE handles the trainer's first pokemon (-> rank 1). We use MAX,
+	-- not COUNT, because gaps in the rank sequence are allowed.
+	SELECT COALESCE(MAX("rank"), 0) + 1
+	INTO _new_rank
+	FROM private.pokemon
+	WHERE trainer_id = _new_trainer_id;
+
+	-- Build the list of pokemon columns to copy, skipping the identity id
+	-- (auto-generated), trainer_id and storage (which we override). This way we
+	-- copy every attribute column without having to enumerate them by hand.
+	SELECT string_agg(quote_ident(column_name), ', ')
+	INTO _cols
+	FROM information_schema.columns
+	WHERE table_schema = 'private'
+		AND table_name   = 'pokemon'
+		AND column_name NOT IN ('id', 'trainer_id', 'rank', 'storage')
+		AND is_generated = 'NEVER'
+		AND identity_generation IS NULL;
+
+	-- Clone the pokemon row under the new trainer and capture the new id. A
+	-- transferred pokemon joins the recipient's party: where the sender kept it
+	-- is the sender's business, and the rank computed above assumes a party slot.
+	EXECUTE format(
+		'INSERT INTO private.pokemon (trainer_id, "rank", storage, %1$s)
+		SELECT $1, $3, ''party'', %1$s FROM private.pokemon WHERE id = $2
+		RETURNING id',
+		_cols
+	)
+	INTO _new_pokemon_id
+	USING _new_trainer_id, _src_pokemon_id, _new_rank;
+
+	-- Deep-copy the related rows, pointing them at the new pokemon.
+	INSERT INTO private.moves (pokemon_id, move_id, pp_cur, pp_max, notes)
+	SELECT _new_pokemon_id, move_id, pp_cur, pp_max, notes
+	FROM private.moves
+	WHERE pokemon_id = _src_pokemon_id;
+
+	INSERT INTO private.held_items (pokemon_id, item_id, custom_name, description)
+	SELECT _new_pokemon_id, item_id, custom_name, description
+	FROM private.held_items
+	WHERE pokemon_id = _src_pokemon_id;
+
+	INSERT INTO private.pokemon_feats (pokemon_id, feat_name, description, is_custom, rank)
+	SELECT _new_pokemon_id, feat_name, description, is_custom, rank
+	FROM private.pokemon_feats
+	WHERE pokemon_id = _src_pokemon_id;
+
+	RETURN _new_pokemon_id;
+END $$ LANGUAGE PLPGSQL VOLATILE SECURITY DEFINER;

--- a/supabase/migrations/20260821162558_pokemon_box.sql
+++ b/supabase/migrations/20260821162558_pokemon_box.sql
@@ -189,13 +189,18 @@ BEGIN
 		RAISE EXCEPTION 'Invalid or expired transfer code';
 	END IF;
 
-	-- Next rank = highest existing rank for the destination trainer + 1.
+	-- Next rank = highest existing rank in the destination trainer's party + 1.
 	-- COALESCE handles the trainer's first pokemon (-> rank 1). We use MAX,
 	-- not COUNT, because gaps in the rank sequence are allowed.
+	--
+	-- The party alone, because ranks are counted within a location: a recipient
+	-- with a full box would otherwise hand the arriving pokemon a rank from a
+	-- list it is not joining.
 	SELECT COALESCE(MAX("rank"), 0) + 1
 	INTO _new_rank
 	FROM private.pokemon
-	WHERE trainer_id = _new_trainer_id;
+	WHERE trainer_id = _new_trainer_id
+		AND storage = 'party';
 
 	-- Build the list of pokemon columns to copy, skipping the identity id
 	-- (auto-generated), trainer_id and storage (which we override). This way we

--- a/supabase/migrations/20260821162558_pokemon_box.sql
+++ b/supabase/migrations/20260821162558_pokemon_box.sql
@@ -11,9 +11,19 @@
 -- pokemon -- a daycare, a second box -- is a new value instead of a reshaped
 -- schema. Adding one means extending the constraint below.
 --
+-- rank is read as (storage, rank) from here on: each location orders itself,
+-- the party 1..N and the box 1..M, with gaps allowed. Two pokemon in different
+-- locations sharing a rank is expected and means nothing, because no list ever
+-- contains both of them. A single sequence spanning the two would have to be
+-- rewritten every time a pokemon crossed between them, and reordering either
+-- list would have to be handed the other one to avoid colliding with it.
+--
 -- get_pokemon RETURNS SETOF private.pokemon and SELECTs *, so the new column
 -- reaches the API with no signature change and no DROP FUNCTION -- the same
--- free ride the tags column got.
+-- free ride the tags column got. It still ORDERs BY rank alone, which now
+-- interleaves the two locations -- harmless, because the app filters the roster
+-- into a party and a box before showing it, and each of those comes out of the
+-- interleaving in its own order.
 
 -- Both clauses in one ALTER TABLE so the table is scanned once. On PG11+ a
 -- constant default is a catalog-only change, so no existing row is rewritten
@@ -30,8 +40,8 @@ ALTER TABLE private.pokemon
 -- Moving a pokemon is its own function rather than another parameter on
 -- update_pokemon. update_pokemon is handed a whole pokemon by the editor and by
 -- the tag updater, so threading the location through it would let any stale
--- copy of a pokemon silently relocate it. It also has to hand out a party rank
--- on the way in, and rank is deliberately something update_pokemon never
+-- copy of a pokemon silently relocate it. It also has to hand out a rank in the
+-- list being joined, and rank is deliberately something update_pokemon never
 -- touches -- only add_pokemon, reorder_pokemon and accept_pokemon_transfer do.
 --
 -- add_pokemon needs nothing: a caught pokemon always joins the party, which the
@@ -50,20 +60,23 @@ DECLARE affected_rows INT;
 BEGIN
 	UPDATE private.pokemon p SET
 		storage = _storage,
-		-- A pokemon rejoining the party goes to the end of it, the same rule
-		-- accept_pokemon_transfer uses. MAX, not COUNT, because gaps in the rank
-		-- sequence are allowed -- every deposit leaves one behind. The subquery
-		-- still sees this row's old rank, so the result is always greater than
-		-- every rank the trainer currently has.
+		-- A pokemon arriving anywhere goes to the end of the list it arrives in,
+		-- the same rule accept_pokemon_transfer uses for the party. Ranks are per
+		-- location, so only the destination's siblings are consulted: a deposit
+		-- takes MAX(rank) + 1 among the box, a withdrawal among the party. MAX,
+		-- not COUNT, because gaps are allowed -- every departure leaves one
+		-- behind. The subquery still sees this row in its old location, so it is
+		-- never counted among its new siblings.
 		--
 		-- The p.storage guard makes the call idempotent. Without it, moving a
-		-- pokemon that is already in the party (a double click, a stale tab)
-		-- would shunt it to the back again. Leaving the party never renumbers, so
-		-- the rest of the party keeps its order.
-		rank = CASE WHEN p.storage <> 'party' AND _storage = 'party' THEN (
+		-- pokemon to where it already is (a double click, a stale tab) would shunt
+		-- it to the back of its own list. Leaving a list never renumbers what
+		-- remains, so the pokemon left behind keep their order.
+		rank = CASE WHEN p.storage <> _storage THEN (
 			SELECT COALESCE(MAX(sibling.rank), 0) + 1
 			FROM private.pokemon sibling
 			WHERE sibling.trainer_id = p.trainer_id
+				AND sibling.storage = _storage
 		) ELSE p.rank END
 	FROM private.trainers t
 	WHERE
@@ -77,6 +90,67 @@ BEGIN
 	GET DIAGNOSTICS affected_rows := ROW_COUNT;
 
 	RETURN affected_rows;
+END $$ LANGUAGE PLPGSQL VOLATILE SECURITY DEFINER;
+
+-- Unchanged from 20260323132133_add_rank_to_pokemon.sql except for the final
+-- UPDATE. Now that each location orders itself, position in the array can no
+-- longer be the rank: renumbering a two-pokemon box 1, 2 while the party is
+-- also 1, 2 is correct, and renumbering the box 1..M from a party-sized offset
+-- would not be.
+--
+-- The caller says which pokemon to renumber and in what order; the storage
+-- column says which list each of them belongs to. Partitioning by it covers
+-- every case in one expression: a party-only call renumbers the party 1..N and
+-- leaves the box alone, a box-only call does the mirror of that, and a call
+-- carrying both splits them and numbers each from 1. The app only ever sends
+-- one list at a time -- the two are dragged separately -- but a mixed call is
+-- the natural thing to try and should not corrupt an ordering.
+--
+-- Pokemon the caller left out keep the rank they had, which is what makes a
+-- filtered list safe to drag: only what was on screen moves.
+CREATE OR REPLACE FUNCTION reorder_pokemon(
+	_write_key VARCHAR(32),
+	_ids INT[]
+) RETURNS VOID as $$
+DECLARE
+	_trainer_id UUID;
+	_mismatch_count INT;
+BEGIN
+	-- Resolve the trainer from the write key
+	SELECT id INTO _trainer_id
+	FROM private.trainers
+	WHERE write_key = _write_key;
+
+	IF NOT FOUND THEN
+		RAISE EXCEPTION 'Invalid write_key';
+	END IF;
+
+	-- Verify every supplied ID belongs to this trainer
+	SELECT COUNT(*) INTO _mismatch_count
+	FROM UNNEST(_ids) AS supplied_id
+	LEFT JOIN private.pokemon p ON p.id = supplied_id AND p.trainer_id = _trainer_id
+	WHERE p.id IS NULL;
+
+	IF _mismatch_count > 0 THEN
+		RAISE EXCEPTION 'Permission denied: % pokemon id(s) do not belong to this trainer', _mismatch_count;
+	END IF;
+
+	-- Reassign ranks by array position, counted from 1 within each location
+	UPDATE private.pokemon p
+	SET rank = ordered.rank
+	FROM (
+		SELECT
+			supplied.id,
+			ROW_NUMBER() OVER (
+				PARTITION BY existing.storage
+				ORDER BY supplied.position
+			) AS rank
+		FROM (
+			SELECT UNNEST(_ids) AS id, GENERATE_SUBSCRIPTS(_ids, 1) AS position
+		) AS supplied
+		JOIN private.pokemon existing ON existing.id = supplied.id
+	) AS ordered
+	WHERE p.id = ordered.id;
 END $$ LANGUAGE PLPGSQL VOLATILE SECURITY DEFINER;
 
 -- Unchanged from 20260609141522_transfer_codes.sql except for the storage

--- a/test/db/after.test.ts
+++ b/test/db/after.test.ts
@@ -678,6 +678,156 @@ test("reordering pokemon", async () => {
 	})
 })
 
+test("depositing and withdrawing pokemon", async () => {
+	const {
+		ret_id: trainerId,
+		ret_write_key: writeKey,
+	} = await call<{
+		ret_id: string,
+		ret_read_key: string,
+		ret_write_key: string,
+	}>("new_trainer", Iris())
+
+	const sunnyYellowId = await call<number>("add_pokemon", {
+		_write_key: writeKey,
+		...SunnyYellow(),
+		_rank: 1,
+	})
+
+	const rosyRedId = await call<number>("add_pokemon", {
+		_write_key: writeKey,
+		...SunnyYellow(),
+		_nickname: "Rosy Red",
+		_rank: 2,
+	})
+
+	const skyBlueId = await call<number>("add_pokemon", {
+		_write_key: writeKey,
+		...SunnyYellow(),
+		_nickname: "Sky Blue",
+		_rank: 3,
+	})
+
+	// Everyone starts in the party
+	const initialPokemon = await callAll<any>("get_pokemon", {
+		_trainer_id: trainerId,
+	})
+	expect(initialPokemon.map((it) => it.storage)).toEqual(["party", "party", "party"])
+
+	// Depositing must not renumber the rest of the party
+	const deposited = await call<number>("set_pokemon_storage", {
+		_write_key: writeKey,
+		_id: rosyRedId,
+		_storage: "box",
+	})
+	expect(deposited).toEqual(1)
+
+	const afterDeposit = await callAll<any>("get_pokemon", {
+		_trainer_id: trainerId,
+	})
+	expect(afterDeposit.filter((it) => it.storage === "box").map((it) => it.id)).toEqual([rosyRedId])
+	expect(afterDeposit.filter((it) => it.storage === "party").map((it) => it.id)).toEqual([sunnyYellowId, skyBlueId])
+
+	// Reordering only the party leaves the boxed pokemon alone
+	await call("reorder_pokemon", {
+		_write_key: writeKey,
+		_ids: [skyBlueId, sunnyYellowId],
+	}, {
+		assertNull: true,
+	})
+
+	const afterReorder = await callAll<any>("get_pokemon", {
+		_trainer_id: trainerId,
+	})
+	expect(afterReorder).toHaveLength(3)
+	expect(afterReorder.find((it) => it.id === rosyRedId).storage).toEqual("box")
+
+	// Withdrawing rejoins the end of the party, so it takes MAX(rank) + 1
+	const withdrawn = await call<number>("set_pokemon_storage", {
+		_write_key: writeKey,
+		_id: rosyRedId,
+		_storage: "party",
+	})
+	expect(withdrawn).toEqual(1)
+
+	const afterWithdraw = await callAll<any>("get_pokemon", {
+		_trainer_id: trainerId,
+	})
+	expect(afterWithdraw.map((it) => it.id)).toEqual([skyBlueId, sunnyYellowId, rosyRedId])
+	const rankAfterWithdraw = afterWithdraw.find((it) => it.id === rosyRedId).rank
+
+	// Withdrawing again is a no-op; it must not march to the back a second time
+	await call<number>("set_pokemon_storage", {
+		_write_key: writeKey,
+		_id: rosyRedId,
+		_storage: "party",
+	})
+
+	const afterSecondWithdraw = await callAll<any>("get_pokemon", {
+		_trainer_id: trainerId,
+	})
+	expect(afterSecondWithdraw.find((it) => it.id === rosyRedId).rank).toEqual(rankAfterWithdraw)
+
+	// Unknown locations are rejected by the check constraint
+	await expect(call<number>("set_pokemon_storage", {
+		_write_key: writeKey,
+		_id: rosyRedId,
+		_storage: "daycare",
+	})).rejects.toThrow()
+
+	// Another trainer's write key changes nothing
+	const {
+		ret_id: otherTrainerId,
+		ret_write_key: otherWriteKey,
+	} = await call<{
+		ret_id: string,
+		ret_read_key: string,
+		ret_write_key: string,
+	}>("new_trainer", Iris())
+
+	const notAffected = await call<number>("set_pokemon_storage", {
+		_write_key: otherWriteKey,
+		_id: sunnyYellowId,
+		_storage: "box",
+	})
+	expect(notAffected).toEqual(0)
+
+	const afterForbidden = await callAll<any>("get_pokemon", {
+		_trainer_id: trainerId,
+	})
+	expect(afterForbidden.find((it) => it.id === sunnyYellowId).storage).toEqual("party")
+
+	// A boxed pokemon can still be released
+	await call<number>("set_pokemon_storage", {
+		_write_key: writeKey,
+		_id: skyBlueId,
+		_storage: "box",
+	})
+	const removed = await call<number>("remove_pokemon", {
+		_write_key: writeKey,
+		_id: skyBlueId,
+	})
+	expect(removed).toEqual(1)
+
+	// Cleanup
+	await call("remove_pokemon", {
+		_write_key: writeKey,
+		_id: sunnyYellowId,
+	})
+	await call("remove_pokemon", {
+		_write_key: writeKey,
+		_id: rosyRedId,
+	})
+	await call("delete_trainer", {
+		_write_key: writeKey,
+		_id: trainerId,
+	})
+	await call("delete_trainer", {
+		_write_key: otherWriteKey,
+		_id: otherTrainerId,
+	})
+})
+
 test("updating movesets", async () => {
 	const {
 		ret_id: trainerId,
@@ -1650,6 +1800,15 @@ test("transfering a pokemon", async () => {
 		_pokemon_id: pokemonId,
 	})).rejects.toThrow()
 
+	// A boxed pokemon must arrive in the recipient's party, not their box. The
+	// clone copies columns enumerated from information_schema, so storage has to
+	// be overridden explicitly.
+	await call<number>("set_pokemon_storage", {
+		_write_key: irisWriteKey,
+		_id: pokemonId,
+		_storage: "box",
+	})
+
 	// correct trainer
 	await call<string>("generate_transfer_code", {
 		_write_key: irisWriteKey,
@@ -1671,6 +1830,13 @@ test("transfering a pokemon", async () => {
 	})
 
 	expect(vivillon.nickname).toEqual("Sunny Yellow")
+	expect(vivillon.storage).toEqual("party")
+
+	// ...while the source keeps its own storage
+	const [sourcePokemon] = await callAll<any>("get_pokemon", {
+		_trainer_id: irisId,
+	})
+	expect(sourcePokemon.storage).toEqual("box")
 
 	// revoking
 	await call("revoke_transfer_code", {

--- a/test/db/after.test.ts
+++ b/test/db/after.test.ts
@@ -1931,6 +1931,21 @@ test("transfering a pokemon", async () => {
 		_storage: "box",
 	})
 
+	// The recipient's only pokemon is a boxed one, so the rank the transfer hands
+	// out has to be counted from their empty party rather than from everything
+	// they own
+	const renibelBoxedId = await call<number>("add_pokemon", {
+		_write_key: renibelWriteKey,
+		...SunnyYellow(),
+		_nickname: "Renibel's Own",
+		_rank: 1,
+	})
+	await call<number>("set_pokemon_storage", {
+		_write_key: renibelWriteKey,
+		_id: renibelBoxedId,
+		_storage: "box",
+	})
+
 	// correct trainer
 	await call<string>("generate_transfer_code", {
 		_write_key: irisWriteKey,
@@ -1947,12 +1962,18 @@ test("transfering a pokemon", async () => {
 		_transfer_code: transferCode,
 	})
 
-	const [vivillon] = await callAll<any>("get_pokemon", {
+	// By nickname, not by position: the arrival and the boxed pokemon both hold
+	// rank 1, one in each list, so which of them comes first is a nickname tie
+	const renibelPokemon = await callAll<any>("get_pokemon", {
 		_trainer_id: renibelId,
 	})
+	const vivillon = renibelPokemon.find((it) => it.nickname === "Sunny Yellow")
 
-	expect(vivillon.nickname).toEqual("Sunny Yellow")
+	expect(vivillon).toBeDefined()
 	expect(vivillon.storage).toEqual("party")
+	// It starts the party rather than taking a number from the box
+	expect(vivillon.rank).toEqual(1)
+	expect(renibelPokemon.find((it) => it.id === renibelBoxedId).rank).toEqual(1)
 
 	// ...while the source keeps its own storage
 	const [sourcePokemon] = await callAll<any>("get_pokemon", {
@@ -1984,6 +2005,10 @@ test("transfering a pokemon", async () => {
 	await call("remove_pokemon", {
 		_write_key: renibelWriteKey,
 		_id: vivillon.id,
+	})
+	await call("remove_pokemon", {
+		_write_key: renibelWriteKey,
+		_id: renibelBoxedId,
 	})
 	await call("delete_trainer", {
 		_write_key: renibelWriteKey,

--- a/test/db/after.test.ts
+++ b/test/db/after.test.ts
@@ -728,6 +728,12 @@ test("depositing and withdrawing pokemon", async () => {
 	expect(afterDeposit.filter((it) => it.storage === "box").map((it) => it.id)).toEqual([rosyRedId])
 	expect(afterDeposit.filter((it) => it.storage === "party").map((it) => it.id)).toEqual([sunnyYellowId, skyBlueId])
 
+	// Ranks count from 1 within a location, so the first pokemon in the box takes
+	// rank 1 no matter how big the party it left is
+	expect(afterDeposit.find((it) => it.id === rosyRedId).rank).toEqual(1)
+	expect(afterDeposit.find((it) => it.id === sunnyYellowId).rank).toEqual(1)
+	expect(afterDeposit.find((it) => it.id === skyBlueId).rank).toEqual(3)
+
 	// Reordering only the party leaves the boxed pokemon alone
 	await call("reorder_pokemon", {
 		_write_key: writeKey,
@@ -741,6 +747,7 @@ test("depositing and withdrawing pokemon", async () => {
 	})
 	expect(afterReorder).toHaveLength(3)
 	expect(afterReorder.find((it) => it.id === rosyRedId).storage).toEqual("box")
+	expect(afterReorder.find((it) => it.id === rosyRedId).rank).toEqual(1)
 
 	// Withdrawing rejoins the end of the party, so it takes MAX(rank) + 1
 	const withdrawn = await call<number>("set_pokemon_storage", {
@@ -754,19 +761,23 @@ test("depositing and withdrawing pokemon", async () => {
 		_trainer_id: trainerId,
 	})
 	expect(afterWithdraw.map((it) => it.id)).toEqual([skyBlueId, sunnyYellowId, rosyRedId])
-	const rankAfterWithdraw = afterWithdraw.find((it) => it.id === rosyRedId).rank
 
-	// Withdrawing again is a no-op; it must not march to the back a second time
+	// Withdrawing a pokemon that never left is a no-op. Sky Blue is at the front
+	// of the party, so a rule that sent every withdrawal to the back would be
+	// caught here: it has to stay exactly where it is.
+	const skyBlueRank = afterWithdraw.find((it) => it.id === skyBlueId).rank
+
 	await call<number>("set_pokemon_storage", {
 		_write_key: writeKey,
-		_id: rosyRedId,
+		_id: skyBlueId,
 		_storage: "party",
 	})
 
 	const afterSecondWithdraw = await callAll<any>("get_pokemon", {
 		_trainer_id: trainerId,
 	})
-	expect(afterSecondWithdraw.find((it) => it.id === rosyRedId).rank).toEqual(rankAfterWithdraw)
+	expect(afterSecondWithdraw.find((it) => it.id === skyBlueId).rank).toEqual(skyBlueRank)
+	expect(afterSecondWithdraw.map((it) => it.id)).toEqual([skyBlueId, sunnyYellowId, rosyRedId])
 
 	// Unknown locations are rejected by the check constraint
 	await expect(call<number>("set_pokemon_storage", {
@@ -825,6 +836,117 @@ test("depositing and withdrawing pokemon", async () => {
 	await call("delete_trainer", {
 		_write_key: otherWriteKey,
 		_id: otherTrainerId,
+	})
+})
+
+test("reordering pokemon within each storage", async () => {
+	const {
+		ret_id: trainerId,
+		ret_write_key: writeKey,
+	} = await call<{
+		ret_id: string,
+		ret_read_key: string,
+		ret_write_key: string,
+	}>("new_trainer", Iris())
+
+	const add = (nickname: string, rank: number) => call<number>("add_pokemon", {
+		_write_key: writeKey,
+		...SunnyYellow(),
+		_nickname: nickname,
+		_rank: rank,
+	})
+
+	const dahliaId = await add("Dahlia", 1)
+	const asterId = await add("Aster", 2)
+	const basilId = await add("Basil", 3)
+	const cedarId = await add("Cedar", 4)
+
+	const roster = async () => {
+		const pokemon = await callAll<any>("get_pokemon", {
+			_trainer_id: trainerId,
+		})
+
+		return {
+			party: pokemon.filter((it) => it.storage === "party"),
+			box: pokemon.filter((it) => it.storage === "box"),
+			rankOf: (id: number) => pokemon.find((it) => it.id === id).rank,
+		}
+	}
+
+	// Deposit, reorder, deposit -- the sequence that used to leave two boxed
+	// pokemon tied at the same rank, because the second deposit was handed a rank
+	// from the party's sequence rather than the box's.
+	await call<number>("set_pokemon_storage", {
+		_write_key: writeKey,
+		_id: basilId,
+		_storage: "box",
+	})
+
+	await call("reorder_pokemon", {
+		_write_key: writeKey,
+		_ids: [asterId, cedarId, dahliaId],
+	}, {
+		assertNull: true,
+	})
+
+	await call<number>("set_pokemon_storage", {
+		_write_key: writeKey,
+		_id: cedarId,
+		_storage: "box",
+	})
+
+	const afterDeposits = await roster()
+	expect(afterDeposits.box.map((it) => it.id)).toEqual([basilId, cedarId])
+	expect(afterDeposits.rankOf(basilId)).toEqual(1)
+	expect(afterDeposits.rankOf(cedarId)).toEqual(2)
+	// The party keeps the ranks the reorder gave it, gap and all
+	expect(afterDeposits.rankOf(asterId)).toEqual(1)
+	expect(afterDeposits.rankOf(dahliaId)).toEqual(3)
+
+	// The box reorders on its own, counting from 1, and the party does not move
+	await call("reorder_pokemon", {
+		_write_key: writeKey,
+		_ids: [cedarId, basilId],
+	}, {
+		assertNull: true,
+	})
+
+	const afterBoxReorder = await roster()
+	expect(afterBoxReorder.box.map((it) => it.id)).toEqual([cedarId, basilId])
+	expect(afterBoxReorder.rankOf(cedarId)).toEqual(1)
+	expect(afterBoxReorder.rankOf(basilId)).toEqual(2)
+	expect(afterBoxReorder.party.map((it) => it.id)).toEqual([asterId, dahliaId])
+	expect(afterBoxReorder.rankOf(asterId)).toEqual(1)
+	expect(afterBoxReorder.rankOf(dahliaId)).toEqual(3)
+
+	// A call carrying both lists at once splits them and numbers each from 1. The
+	// app never does this -- the two lists are dragged separately -- but it is the
+	// natural thing to try, so it must not scramble either ordering.
+	await call("reorder_pokemon", {
+		_write_key: writeKey,
+		_ids: [dahliaId, basilId, asterId, cedarId],
+	}, {
+		assertNull: true,
+	})
+
+	const afterMixedReorder = await roster()
+	expect(afterMixedReorder.party.map((it) => it.id)).toEqual([dahliaId, asterId])
+	expect(afterMixedReorder.rankOf(dahliaId)).toEqual(1)
+	expect(afterMixedReorder.rankOf(asterId)).toEqual(2)
+	expect(afterMixedReorder.box.map((it) => it.id)).toEqual([basilId, cedarId])
+	expect(afterMixedReorder.rankOf(basilId)).toEqual(1)
+	expect(afterMixedReorder.rankOf(cedarId)).toEqual(2)
+
+	// Cleanup
+	for (const id of [dahliaId, asterId, basilId, cedarId]) {
+		await call("remove_pokemon", {
+			_write_key: writeKey,
+			_id: id,
+		})
+	}
+	await call("delete_trainer", {
+		_write_key: writeKey,
+		_id: trainerId,
 	})
 })
 

--- a/test/db/before.test.ts
+++ b/test/db/before.test.ts
@@ -1355,6 +1355,266 @@ test("updating fakemon evolution lines", async () => {
 	expect(ascendeonEvolutionsAfterRemoval.length).toEqual(0)
 })
 
+async function setupEeveeDrakeonAscendeon() {
+	const {
+		ret_id: drakeonId,
+		ret_read_key: drakeonReadKey,
+		ret_write_key: drakeonWriteKey
+	} = await call<{
+		ret_id: string,
+		ret_read_key: string,
+		ret_write_key: string,
+	}>("new_fakemon", Drakeon())
+
+	const drakeonFkey = `F.${drakeonReadKey}`
+
+	const {
+		ret_id: ascendeonId,
+		ret_read_key: ascendeonReadKey,
+		ret_write_key: ascendeonWriteKey
+	} = await call<{
+		ret_id: string,
+		ret_read_key: string,
+		ret_write_key: string,
+	}>("new_fakemon", {
+		...Drakeon(),
+		_species_name: "Ascendeon",
+		_type: ["Normal"],
+	})
+
+	const ascendeonFkey = `F.${ascendeonReadKey}`
+
+	const drakeonEvoId = await call("add_fakemon_evolution", {
+		_from_id: "eevee",
+		_from_write_key: null,
+		_to_id: drakeonFkey,
+		_to_write_key: drakeonWriteKey,
+		_conditions: JSON.stringify([ {
+			type: "level",
+			value: 8,
+		} ]),
+		_effects: JSON.stringify([ {
+			type: "asi",
+			value: 10,
+		} ]),
+	})
+
+	const ascendeonEvoId = await call("add_fakemon_evolution", {
+		_from_id: drakeonFkey,
+		_from_write_key: drakeonWriteKey,
+		_to_id: ascendeonFkey,
+		_to_write_key: ascendeonWriteKey,
+		_conditions: JSON.stringify([ {
+			type: "level",
+			value: 15,
+		} ]),
+		_effects: JSON.stringify([ {
+			type: "asi",
+			value: 6,
+		} ]),
+	})
+
+	return {
+		drakeonEvoId,
+		ascendeonEvoId,
+		drakeonFkey,
+		drakeonWriteKey,
+		ascendeonFkey,
+		ascendeonWriteKey,
+	}
+}
+
+test("specific write permissions for fakemon evolution lines", async () => {
+	// Test: Removing drakeon -> ascendeon with only one write key
+	const {
+		ascendeonEvoId: removeWithOneAscendeonEvoId,
+		ascendeonFkey: removeWithOneAscendeonFKey,
+		ascendeonWriteKey: removeWithOneAscendeonWriteKey,
+	} = await setupEeveeDrakeonAscendeon()
+
+	await call("remove_fakemon_evolution", {
+		_id: removeWithOneAscendeonEvoId,
+		_original_from_write_key: null, // we only have write access to ascendeon
+		_original_to_write_key: removeWithOneAscendeonWriteKey,
+	})
+
+	const withOneAfterRemoval = await callAll<any>("get_fakemon_evolutions", {
+		_fakemon_id: removeWithOneAscendeonFKey,
+	})
+
+	expect(withOneAfterRemoval.length).toEqual(0)
+
+	// Test: Removing drakeon -> ascendeon with no write keys
+	const {
+		ascendeonEvoId: removeWithZeroAscendeonEvoId,
+		ascendeonFkey: removeWithZeroAscendeonFKey,
+	} = await setupEeveeDrakeonAscendeon()
+
+	await call("remove_fakemon_evolution", {
+		_id: removeWithZeroAscendeonEvoId,
+		_original_from_write_key: null,
+		_original_to_write_key: null,
+	})
+
+	const withZeroAfterRemoval = await callAll<any>("get_fakemon_evolutions", {
+		_fakemon_id: removeWithZeroAscendeonFKey,
+	})
+
+	expect(withZeroAfterRemoval.length).toEqual(1)
+
+	// Test: cannot remove eevee -> drakeon with no write keys
+	const {
+		drakeonEvoId: canonRemoveEvoId,
+		drakeonFkey: canonRemoveDrakeonFKey,
+	} = await setupEeveeDrakeonAscendeon()
+
+	const canonRemoveResult = await call("remove_fakemon_evolution", {
+		_id: canonRemoveEvoId,
+		_original_from_write_key: null, // eevee is canon, stored key is NULL
+		_original_to_write_key: null,
+	})
+
+	expect(canonRemoveResult).toEqual(0)
+
+	const canonAfterRemoval = await callAll<any>("get_fakemon_evolutions", {
+		_fakemon_id: canonRemoveDrakeonFKey,
+	})
+
+	expect(canonAfterRemoval.length).toEqual(2) // eevee, and ascendeon; eevee was not removed
+
+	// Test: updating drakeon -> ascendeon with only one write key
+	const {
+		ascendeonEvoId: updateWithOneAscendeonEvoId,
+		ascendeonFkey: updateWithOneAscendeonFKey,
+		ascendeonWriteKey: updateWithOneAscendeonWriteKey,
+	} = await setupEeveeDrakeonAscendeon()
+
+	await call("update_fakemon_evolution", {
+		_id: updateWithOneAscendeonEvoId,
+		_original_from_write_key: null, // only have ascendeon
+		_original_to_write_key: updateWithOneAscendeonWriteKey,
+		_from_id: "eevee",
+		_from_write_key: null,
+		_to_id: updateWithOneAscendeonFKey,
+		_to_write_key: updateWithOneAscendeonWriteKey,
+		_conditions: JSON.stringify([ {
+			type: "level",
+			value: 10,
+		} ]),
+		_effects: JSON.stringify([ {
+			type: "asi",
+			value: 8,
+		} ]),
+	})
+
+	const withOneAfterUpdate = await callAll<any>("get_fakemon_evolutions", {
+		_fakemon_id: updateWithOneAscendeonFKey,
+	})
+
+	expect(withOneAfterUpdate.length).toEqual(1)
+	expect(withOneAfterUpdate[0].from_id).toEqual("eevee")
+
+	// Test: updating drakeon -> ascendeon with only no write keys
+	const {
+		ascendeonEvoId: updateWithZeroAscendeonEvoId,
+		drakeonFkey: updateWithZeroDrakeonFKey,
+		ascendeonFkey: updateWithZeroAscendeonFKey,
+		ascendeonWriteKey: updateWithZeroAscendeonWriteKey,
+	} = await setupEeveeDrakeonAscendeon()
+
+	await call("update_fakemon_evolution", {
+		_id: updateWithZeroAscendeonEvoId,
+		_original_from_write_key: null,
+		_original_to_write_key: null, // no keys
+		_from_id: "eevee",
+		_from_write_key: null,
+		_to_id: updateWithZeroAscendeonFKey,
+		_to_write_key: updateWithZeroAscendeonWriteKey, // even if you somehow had it here?
+		_conditions: JSON.stringify([ {
+			type: "level",
+			value: 10,
+		} ]),
+		_effects: JSON.stringify([ {
+			type: "asi",
+			value: 8,
+		} ]),
+	})
+
+	const withZeroAfterUpdate = await callAll<any>("get_fakemon_evolutions", {
+		_fakemon_id: updateWithZeroAscendeonFKey,
+	})
+
+	expect(withZeroAfterUpdate.length).toEqual(1)
+	expect(withZeroAfterUpdate[0].from_id).toEqual(updateWithZeroDrakeonFKey)
+
+	// Test: cannot update eevee -> drakeon with no write key
+	const {
+		drakeonEvoId: canonUpdateEvoId,
+		drakeonFkey: canonUpdateDrakeonFKey,
+		ascendeonFkey: canonUpdateAscendeonFKey,
+		ascendeonWriteKey: canonUpdateAscendeonWriteKey,
+	} = await setupEeveeDrakeonAscendeon()
+
+	await call("update_fakemon_evolution", {
+		_id: canonUpdateEvoId,
+		_original_from_write_key: null,
+		_original_to_write_key: null, // no keys
+		_from_id: "eevee",
+		_from_write_key: null,
+		_to_id: canonUpdateAscendeonFKey,
+		_to_write_key: canonUpdateAscendeonWriteKey,
+		_conditions: JSON.stringify([ {
+			type: "level",
+			value: 10,
+		} ]),
+		_effects: JSON.stringify([ {
+			type: "asi",
+			value: 8,
+		} ]),
+	})
+
+	const canonAfterUpdate = await callAll<any>("get_fakemon_evolutions", {
+		_fakemon_id: canonUpdateDrakeonFKey,
+	})
+
+	expect(canonAfterUpdate.length).toEqual(2)
+	expect(canonAfterUpdate[0].to_id).toEqual(canonUpdateDrakeonFKey)
+	expect(canonAfterUpdate[1].to_id).toEqual(canonUpdateAscendeonFKey)
+
+	// Test: cannot attach to a fakemon you do not own
+	const {
+		drakeonEvoId: canonToUnownedUpdateEvoId,
+		drakeonFkey: canonToUnownedUpdateDrakeonFKey,
+		ascendeonFkey: canonToUnownedUpdateAscendeonFKey,
+		ascendeonWriteKey: canonToUnownedUpdateAscendeonWriteKey,
+	} = await setupEeveeDrakeonAscendeon()
+
+	await call("update_fakemon_evolution", {
+		_id: canonToUnownedUpdateEvoId,
+		_original_from_write_key: null,
+		_original_to_write_key: null, // no keys
+		_from_id: "eevee",
+		_from_write_key: null,
+		_to_id: canonToUnownedUpdateAscendeonFKey,
+		_to_write_key: "not owned",
+		_conditions: JSON.stringify([ {
+			type: "level",
+			value: 10,
+		} ]),
+		_effects: JSON.stringify([ {
+			type: "asi",
+			value: 8,
+		} ]),
+	})
+
+	const canonToUnownedAfterUpdate = await callAll<any>("get_fakemon_evolutions", {
+		_fakemon_id: canonToUnownedUpdateDrakeonFKey,
+	})
+
+	expect(canonToUnownedAfterUpdate.length).toEqual(2)
+	expect(canonToUnownedAfterUpdate[0].from_id).toEqual("eevee")
+})
+
 test("transfering a pokemon", async () => {
 	const {
 		ret_id: irisId,


### PR DESCRIPTION
This PR are splitting the previous PR #431 into two due to the request from Auroratide.

This is just the DB migration and tests for that migration.

